### PR TITLE
Add z-index 1000 to extension modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-solutions-css",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "Consolidated CSS for OpenTok Accelerator Packs",
   "main": "style.css",
   "scripts": {

--- a/style.css
+++ b/style.css
@@ -592,6 +592,7 @@ only screen and (min-device-pixel-ratio:1.5) {
     left: 0;
     right: 0;
     background: rgba(0, 0, 0, 0.1);
+    z-index:1000;
 }
 
 .ots-ss-modal .ots-modal-body {


### PR DESCRIPTION
This PR adds the z-index property to the ots-ss-modal that is used by the extension modal.
This way it will appear in front of the full screen view.

@adrice727 Could you please review this PR? Thanks!
